### PR TITLE
Update pourover and cupping schemas

### DIFF
--- a/schemas/coffee.json
+++ b/schemas/coffee.json
@@ -11,6 +11,11 @@
       "default": 0,
       "description": "The number of clicks, with zero being when burrs are fully closed."
     },
+    "variety": {
+      "type": "string",
+      "default": "",
+      "description": "The variety of the coffee, such as 'Pacas' or 'Gesha'."
+    },
     "origin": {
       "type": "object",
       "properties": {
@@ -24,7 +29,7 @@
           "default": "",
           "description": "The region, such as 'Guji' or 'Gitwe'."
         },
-        "grower": {
+        "producer": {
           "type": "string",
           "default": "",
           "description": "The farmer, collective, or coop, such as 'Nano Challa' or 'Ariz Family'."

--- a/src/cli/update.js
+++ b/src/cli/update.js
@@ -40,7 +40,7 @@ export const handler = ({ type, from, to }) => pipeWith(andThen, [
   mapAsync(async filename => {
     const entry = await getEntryByFilename(filename);
     // const newEntry = ... some transform to entry given the type, from, and to
-    newEntry = {};
+    const newEntry = entry;
     await writeEntry(filename, newEntry)
   })
 ])();


### PR DESCRIPTION
- Adds `coffee.variety`
- Rephrases `coffee.origin.{grower => producer}`