### PR TITLE
Schema update: add default value to coffee.roaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ kafi stats pourover --equipment.grinder="Baratza Encore" --coffee.grind=23
 
 ## Developers
 
-To publish your own journal schema:
+To build your own journal schema:
 1. Create a new JSON Schema file at `{rootDir}/src/schema/{method}.json`. Common subschemas such as `coffee.json` and `water.json` are provided.
-2. Run the `publish-schema` command:
+2. Run the `build-schema` command:
 ```shell
-# Example: npm run publish-schema --type=espresso --release=1.0
-npm run publish-schema --type={method} --release={version}
+# Example: npm run build-schema --type=espresso --release=1.1
+npm run build-schema --type={method} --release={version}
 ```
 
 ## Methods

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "ava",
-    "publish-schema": "json-dereference -s \"src/schema/${npm_config_type}.json\" -o \"schemas/${npm_config_type}_v${npm_config_release}.json\""
+    "build-schema": "json-dereference -s \"src/schema/${npm_config_type}.json\" -o \"schemas/${npm_config_type}_v${npm_config_release}.json\""
   },
   "bin": {
     "kafi": "index.js"

--- a/schemas/cupping_v1.1.json
+++ b/schemas/cupping_v1.1.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "../schemas/cupping_v1.1.json",
+      "default": "../schemas/cupping_v1.1.json",
+      "description": "The JSON schema to validate this journal entry against."
+    },
+    "type": {
+      "const": "cupping",
+      "default": "cupping",
+      "description": "The type of journal entry."
+    },
+    "date": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "string",
+          "pattern": "^\\d{2}/\\d{2}/\\d{4}$",
+          "default": ""
+        }
+      ],
+      "description": "The date you cupped this coffee, formatted as 'MM/DD/YYYY'."
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 0,
+      "description": "The (n - 1) coffee today."
+    },
+    "coffee": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "weight": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+g$",
+                  "default": ""
+                }
+              ],
+              "description": "The weight of the coffee beans in grams, such as '30g'."
+            },
+            "grind": {
+              "type": "integer",
+              "default": 0,
+              "description": "The number of clicks, with zero being when burrs are fully closed."
+            },
+            "variety": {
+              "type": "string",
+              "default": "",
+              "description": "The variety of the coffee, such as 'Pacas' or 'Gesha'."
+            },
+            "origin": {
+              "type": "object",
+              "properties": {
+                "country": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The country, such as 'Ethiopia' or 'Rwanda'."
+                },
+                "region": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The region, such as 'Guji' or 'Gitwe'."
+                },
+                "producer": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The farmer, collective, or coop, such as 'Nano Challa' or 'Ariz Family'."
+                }
+              },
+              "description": "The area in which this coffee was grown.",
+              "required": ["country", "region", "grower"]
+            },
+            "roaster": {
+              "type": "string",
+              "default": "",
+              "description": "The name of the individual or business who roasted the coffee."
+            },
+            "roastDate": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d{2}/\\d{2}/\\d{4}$",
+                  "default": ""
+                }
+              ],
+              "description": "The date this coffee was roasted, formatted as 'MM/DD/YYYY'."
+            }
+          },
+          "required": ["weight", "grind", "origin", "roaster", "roastDate"]
+        }
+      ],
+      "description": "The coffee beans used in your cupping."
+    },
+    "water": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "weight": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+g$",
+                  "default": ""
+                }
+              ],
+              "description": "The weight of the water in grams, such as '500g'."
+            },
+            "temperature": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+º[FC]$",
+                  "default": "212ºF"
+                }
+              ],
+              "description": "The temperature at which you began brewing."
+            },
+            "recipe": {
+              "type": "string",
+              "default": "",
+              "description": "The recipe you used for your water."
+            }
+          },
+          "required": ["weight", "temperature", "recipe"]
+        }
+      ],
+      "description": "The water used in your cupping."
+    },
+    "equipment": {
+      "type": "object",
+      "properties": {
+        "grinder": {
+          "type": "string",
+          "default": "",
+          "description": "The grinder make and model you used, such as 'Hario Skerton' or 'Baratza Encore'."
+        }
+      },
+      "description": "The equipment used to make this cupping.",
+      "required": ["grinder"]
+    },
+    "recipe": {
+      "type": "object",
+      "properties": {
+        "steep": {
+          "type": "object",
+          "properties": {
+            "time": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d{1}:\\d{2}$",
+                  "default": ""
+                }
+              ],
+              "description": "The total time from your initial pour on dry grounds to breaking the crust."
+            }
+          },
+          "description": "The steep settings you cupped with.",
+          "required": ["time"]
+        },
+        "notes": {
+          "type": "string",
+          "default": "",
+          "description": "Any notes on techniques used for your cupping."
+        }
+      },
+      "description": "The techniques you used to cup.",
+      "required": ["steep", "notes"]
+    },
+    "aroma": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The smell (low to high), such as 'caramel', 'peach', or 'chocolate'."
+    },
+    "acidity": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The fruitiness (low to high), such as 'tart', 'crisp', or 'mellow'. Usually indicated by puckering/drying of the tongue or salivation."
+    },
+    "sweetness": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The sweetness (low to high), such as 'mild', 'deep', or 'rich'. Usually indicated by how 'rounded' the fruit quality is."
+    },
+    "body": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The texture or mouthfeel (light to heavy), such as 'watery', 'silky', 'syrupy', or 'creamy'."
+    },
+    "finish": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The aftertaste (short to long), such as 'quick', 'lingering', or 'clean'. Don't rush this aspect."
+    },
+    "notes": {
+      "type": "string",
+      "default": "",
+      "description": "Any notes about this cupping, such as overall flavor."
+    },
+    "score": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "default": 0,
+      "description": "On a scale of 1 to 10, how much did you enjoy this cupping?"
+    },
+    "actionItem": {
+      "type": "string",
+      "default": "",
+      "description": "Any variables to change on the next cupping."
+    }
+  },
+  "required": [
+    "type",
+    "date",
+    "coffee",
+    "water",
+    "equipment",
+    "recipe",
+    "aroma",
+    "acidity",
+    "sweetness",
+    "body",
+    "finish",
+    "notes",
+    "score",
+    "actionItem"
+  ]
+}

--- a/schemas/pourover_v1.1.json
+++ b/schemas/pourover_v1.1.json
@@ -1,0 +1,406 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "../schemas/pourover_v1.1.json",
+      "default": "../schemas/pourover_v1.1.json",
+      "description": "The JSON schema to validate this journal entry against."
+    },
+    "type": {
+      "const": "pourover",
+      "default": "pourover",
+      "description": "The type of journal entry."
+    },
+    "date": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "string",
+          "pattern": "^\\d{2}/\\d{2}/\\d{4}$",
+          "default": ""
+        }
+      ],
+      "description": "The date you brewed this coffee, formatted as 'MM/DD/YYYY'."
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 0,
+      "description": "The (n - 1) coffee today."
+    },
+    "coffee": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "weight": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+g$",
+                  "default": ""
+                }
+              ],
+              "description": "The weight of the coffee beans in grams, such as '30g'."
+            },
+            "grind": {
+              "type": "integer",
+              "default": 0,
+              "description": "The number of clicks, with zero being when burrs are fully closed."
+            },
+            "variety": {
+              "type": "string",
+              "default": "",
+              "description": "The variety of the coffee, such as 'Pacas' or 'Gesha'."
+            },
+            "origin": {
+              "type": "object",
+              "properties": {
+                "country": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The country, such as 'Ethiopia' or 'Rwanda'."
+                },
+                "region": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The region, such as 'Guji' or 'Gitwe'."
+                },
+                "producer": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The farmer, collective, or coop, such as 'Nano Challa' or 'Ariz Family'."
+                }
+              },
+              "description": "The area in which this coffee was grown.",
+              "required": ["country", "region", "grower"]
+            },
+            "roaster": {
+              "type": "string",
+              "default": "",
+              "description": "The name of the individual or business who roasted the coffee."
+            },
+            "roastDate": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d{2}/\\d{2}/\\d{4}$",
+                  "default": ""
+                }
+              ],
+              "description": "The date this coffee was roasted, formatted as 'MM/DD/YYYY'."
+            }
+          },
+          "required": ["weight", "grind", "origin", "roaster", "roastDate"]
+        }
+      ],
+      "description": "The coffee beans used in your brew."
+    },
+    "water": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "weight": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+g$",
+                  "default": ""
+                }
+              ],
+              "description": "The weight of the water in grams, such as '500g'."
+            },
+            "temperature": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+º[FC]$",
+                  "default": "212ºF"
+                }
+              ],
+              "description": "The temperature at which you began brewing."
+            },
+            "recipe": {
+              "type": "string",
+              "default": "",
+              "description": "The recipe you used for your water."
+            }
+          },
+          "required": ["weight", "temperature", "recipe"]
+        }
+      ],
+      "description": "The water used in your brew."
+    },
+    "equipment": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "default": "",
+          "description": "The method used to brew your coffee, such as 'Chemex' or 'Hario V60'."
+        },
+        "grinder": {
+          "type": "string",
+          "default": "",
+          "description": "The grinder make and model you used, such as 'Hario Skerton' or 'Baratza Encore'."
+        }
+      },
+      "description": "The equipment used to make this brew.",
+      "required": ["method", "grinder"]
+    },
+    "recipe": {
+      "type": "object",
+      "properties": {
+        "bloom": {
+          "type": "object",
+          "properties": {
+            "weight": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+g$",
+                  "default": ""
+                }
+              ],
+              "description": "The weight of the bloom water in grams, such as '50g'."
+            },
+            "time": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d{1}:\\d{2}$",
+                  "default": ""
+                }
+              ],
+              "description": "The total time from your initial pour on dry grounds to the next pour."
+            }
+          },
+          "description": "The bloom settings you brewed with.",
+          "required": ["weight", "time"]
+        },
+        "notes": {
+          "type": "string",
+          "default": "",
+          "description": "Any notes on techniques used for your brew."
+        }
+      },
+      "description": "The techniques you used to brew.",
+      "required": ["bloom", "notes"]
+    },
+    "time": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "string",
+          "pattern": "^\\d{1}:\\d{2}$",
+          "default": ""
+        }
+      ],
+      "description": "The total time from beginning of bloom until a steady stream suddenly falters to separate drops, such as '2:54'."
+    },
+    "aroma": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The smell (low to high), such as 'caramel', 'peach', or 'chocolate'."
+    },
+    "acidity": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The fruitiness (low to high), such as 'tart', 'crisp', or 'mellow'. Usually indicated by puckering/drying of the tongue or salivation."
+    },
+    "sweetness": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The sweetness (low to high), such as 'mild', 'deep', or 'rich'. Usually indicated by how 'rounded' the fruit quality is."
+    },
+    "body": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The texture or mouthfeel (light to heavy), such as 'watery', 'silky', 'syrupy', or 'creamy'."
+    },
+    "finish": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The aftertaste (short to long), such as 'quick', 'lingering', or 'clean'. Don't rush this aspect."
+    },
+    "notes": {
+      "type": "string",
+      "default": "",
+      "description": "Any notes about this brew, such as drawdown or overall flavor."
+    },
+    "score": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "default": 0,
+      "description": "On a scale of 1 to 10, how much did you enjoy this brew?"
+    },
+    "actionItem": {
+      "type": "string",
+      "default": "",
+      "description": "Any variables to change on the next brew."
+    }
+  },
+  "required": [
+    "type",
+    "date",
+    "coffee",
+    "water",
+    "equipment",
+    "recipe",
+    "time",
+    "aroma",
+    "acidity",
+    "sweetness",
+    "body",
+    "finish",
+    "notes",
+    "score",
+    "actionItem"
+  ]
+}

--- a/src/cli/journal/index.js
+++ b/src/cli/journal/index.js
@@ -68,7 +68,7 @@ export const builder = yargs => yargs
     choices: ['pourover', 'cupping'],
     required: true
   })
-export const handler = async ({ type, version = '1.0' }) => {
+export const handler = async ({ type, version = '1.1' }) => {
   const today = dayjs();
   let basename = today.format(DATE_FORMAT);
   const defaults = await getJSONSchema(version, type)

--- a/src/schema/coffee.json
+++ b/src/schema/coffee.json
@@ -40,6 +40,7 @@
     },
     "roaster": {
       "type": "string",
+      "default": "",
       "description": "The name of the individual or business who roasted the coffee."
     },
     "roastDate": {

--- a/src/schema/cupping.json
+++ b/src/schema/cupping.json
@@ -3,8 +3,8 @@
   "type": "object",
   "properties": {
     "$schema": {
-      "const": "../schemas/cupping_v1.0.json",
-      "default": "../schemas/cupping_v1.0.json",
+      "const": "../schemas/cupping_v1.1.json",
+      "default": "../schemas/cupping_v1.1.json",
       "description": "The JSON schema to validate this journal entry against."
     },
     "type": {

--- a/src/schema/pourover.json
+++ b/src/schema/pourover.json
@@ -3,8 +3,8 @@
   "type": "object",
   "properties": {
     "$schema": {
-      "const": "../schemas/pourover_v1.0.json",
-      "default": "../schemas/pourover_v1.0.json",
+      "const": "../schemas/pourover_v1.1.json",
+      "default": "../schemas/pourover_v1.1.json",
       "description": "The JSON schema to validate this journal entry against."
     },
     "type": {


### PR DESCRIPTION
When starting from an empty journal, user will not see `coffee.roaster` field. This is because no default field was set in the schema, resulting in `undefined`.

This is now fixed in the updated schemas.

Bumps schema versions:
- `cupping_v{1.0 => 1.1}`
- `pourover_v{1.0=>1.1}`