### PR TITLE
Add merging feature to stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ kafi stats pourover --fields coffee.origin.region coffee.grind time
 kafi stats pourover --sort coffee.roaster score coffee.grind
 # Filter results by properties
 kafi stats pourover --equipment.grinder="Baratza Encore" --coffee.grind=23
+# Merge entries on property (overrides --sort)
+kafi stats pourover --merge coffee.grind --fields score
 ```
 
 ## Developers

--- a/src/cli/stats.js
+++ b/src/cli/stats.js
@@ -1,26 +1,4 @@
-import R, { pipe } from 'ramda';
-const {
-  add,
-  andThen,
-  ascend,
-  compose,
-  cond,
-  curry,
-  eqProps,
-  equals,
-  filter,
-  fromPairs,
-  groupWith,
-  map,
-  mergeWith,
-  pipeWith,
-  reduce,
-  sortWith,
-  takeLast,
-  tap,
-  useWith,
-  when
-} = R;
+import R from 'ramda';
 import {
   dateComparator,
   dateFromFriendlyDate,
@@ -30,6 +8,38 @@ import {
   partialEq,
   pathString
 } from '../util';
+const {
+  andThen,
+  all,
+  always,
+  ascend,
+  both,
+  compose,
+  converge,
+  cond,
+  curry,
+  divide,
+  eqProps,
+  equals,
+  filter,
+  fromPairs,
+  groupWith,
+  head,
+  ifElse,
+  isEmpty,
+  length,
+  map,
+  mergeWith,
+  pipe,
+  pipeWith,
+  reduce,
+  sortWith,
+  sum,
+  takeLast,
+  tap,
+  useWith,
+  when
+} = R;
 
 /**
  * @todo takeLast() is more specific to sorting by date. Most times we want the first N entries.
@@ -44,12 +54,19 @@ import {
 const DEFAULT_SORT_FIELDS = ['date'];
 const DEFAULT_FIELDS = ['coffee.roaster', 'coffee.origin.region', 'coffee.grind', 'score'];
 
+const isNumber = both(
+  num => typeof num === 'number',
+  num => !Number.isNaN(num)
+);
+
+const average = ifElse(isEmpty, () => 0, converge(divide, [sum, length]));
+
 const flattenEntriesByAverage = curry((sortField, entries) => pipe(
   groupWith(eqProps(sortField)),
   map(duplicates => {
-    const length = duplicates.length;
-    const reduced = reduce(mergeWith(add), {}, duplicates);
-    return map(value => parseFloat((value / length).toFixed(1)), reduced);
+    const emptyObject = map(always([]), duplicates[0]);
+    const reduced = reduce(mergeWith((a, b) => a.concat([b])), emptyObject, duplicates);
+    return map(ifElse(all(isNumber), pipe(average, num => parseFloat(num).toFixed(1)), head), reduced);
   })
 )(entries));
 


### PR DESCRIPTION
Adds new `--merge` flag (overrides `--sort`):

```shell
kafi stats <cupping|pourover> --fields score --merge coffee.grind
┌─────────┬──────────────┬───────┐
│ (index) │ coffee.grind │ score │
├─────────┼──────────────┼───────┤
│    0    │      9       │  4.8  │
│    1    │      19      │   6   │
│    2    │      20      │  7.1  │
│    3    │      21      │  6.1  │
│    4    │      22      │  5.7  │
│    5    │      23      │  6.7  │
│    6    │      24      │  6.2  │
│    7    │      25      │   6   │
└─────────┴──────────────┴───────┘
```

While there are a number of bugs and edge cases present, this feature has proved extremely useful over months of testing for discovering:
- Reasonable highest grind setting to begin dialing in a new coffee
- Correlation between the intensity of an aspect (i.e. acidity) and the resulting score
- Favorite origins

For now, this feature only supports fields that can be averaged (although you can merge on a string field). In the future, I hope to add capabilities for number-like strings such as `55g` and `2:54`.
