### PR TITLE
Display array-like values as human-readable strings

### DIFF
--- a/src/cli/stats.js
+++ b/src/cli/stats.js
@@ -27,6 +27,7 @@ const {
   head,
   ifElse,
   isEmpty,
+  join,
   length,
   map,
   mergeWith,
@@ -118,6 +119,7 @@ export const handler = ({ ['$0']: pos, _, stats, fn, fields, limit, merge, sort:
     map(strainBy([...sort, ...fields])),
     when(() => !!merge, mergeEntriesOnKey(merge)),
     takeLast(limit),
+    map(map(when(Array.isArray, join(', ')))),
     tap(console.table),
   ])();
 };


### PR DESCRIPTION
Turns values like `acidity.descriptors` into readable strings:
```json
{
  "acidity": {
    "descriptors": ["plump", "juicy", "pear"]
  }
}
```
```shell
kafi stats pourover --fields acidity.descriptors

┌─────────┬──────────────┬───────────────────────────────────────────────────────────────────────────────────────┐
│ (index) │     date     │                                  acidity.descriptors                                  │
├─────────┼──────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
│    0    │ '02/16/2021' │                                 'plump, juicy, pear'                                  │
│    1    │ '02/16/2021' │ 'mouthwatering, ruddy, harsh, red, indistinct, bite, plum, meyer lemon, ripe, savory' │
└─────────┴──────────────┴───────────────────────────────────────────────────────────────────────────────────────┘
```