### PR TITLE
Add hybrid schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm link
 
 ```shell
 # create a new journal entry with sane defaults
-kafi journal <cupping|pourover>
+kafi journal <cupping|hybrid|pourover>
 ```
 
 4. Brew your coffee, then jot out your reactions to things like:
@@ -62,7 +62,7 @@ kafi journal <cupping|pourover>
 
 ```shell
 # Create a new journal entry
-kafi journal <cupping|pourover>
+kafi journal <cupping|hybrid|pourover>
 ```
 
 ### Stats
@@ -91,7 +91,7 @@ $ kafi stats pourover --coffee.origin.region="Pitalito"
 
 ```shell
 # Basic use
-kafi stats <cupping|pourover>
+kafi stats <cupping|hybrid|pourover>
 # Limit entries (defaults to last 30)
 kafi stats pourover --limit 10
 # Display specific fields (defaults to coffee.roaster, coffee.origin.country, coffee.grind, score)

--- a/package-lock.json
+++ b/package-lock.json
@@ -946,9 +946,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.3.tgz",
-      "integrity": "sha512-/2fdLN987N8Ki7Id8BUN2nhuiRyxTLumQnSQf9CNncFCyqFsSKb9TNhzRYcC8K8eJSJOKvbvkImo/MKKhNi4iw=="
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
     },
     "debug": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/manuscriptmastr/kafi#readme",
   "dependencies": {
-    "dayjs": "^1.10.3",
+    "dayjs": "^1.10.4",
     "json-schema-defaults": "^0.4.0",
     "ramda": "^0.27.1",
     "yargs": "^16.2.0"

--- a/schemas/hybrid_v1.1.json
+++ b/schemas/hybrid_v1.1.json
@@ -1,0 +1,395 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "../schemas/hybrid_v1.1.json",
+      "default": "../schemas/hybrid_v1.1.json",
+      "description": "The JSON schema to validate this journal entry against."
+    },
+    "type": {
+      "const": "hybrid",
+      "default": "hybrid",
+      "description": "The type of journal entry."
+    },
+    "date": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "string",
+          "pattern": "^\\d{2}/\\d{2}/\\d{4}$",
+          "default": ""
+        }
+      ],
+      "description": "The date you brewed this coffee, formatted as 'MM/DD/YYYY'."
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 0,
+      "description": "The (n - 1) coffee today."
+    },
+    "coffee": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "weight": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+g$",
+                  "default": ""
+                }
+              ],
+              "description": "The weight of the coffee beans in grams, such as '30g'."
+            },
+            "grind": {
+              "type": "integer",
+              "default": 0,
+              "description": "The number of clicks, with zero being when burrs are fully closed."
+            },
+            "variety": {
+              "type": "string",
+              "default": "",
+              "description": "The variety of the coffee, such as 'Pacas' or 'Gesha'."
+            },
+            "origin": {
+              "type": "object",
+              "properties": {
+                "country": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The country, such as 'Ethiopia' or 'Rwanda'."
+                },
+                "region": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The region, such as 'Guji' or 'Gitwe'."
+                },
+                "producer": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The farmer, collective, or coop, such as 'Nano Challa' or 'Ariz Family'."
+                }
+              },
+              "description": "The area in which this coffee was grown.",
+              "required": ["country", "region", "grower"]
+            },
+            "roaster": {
+              "type": "string",
+              "default": "",
+              "description": "The name of the individual or business who roasted the coffee."
+            },
+            "roastDate": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d{2}/\\d{2}/\\d{4}$",
+                  "default": ""
+                }
+              ],
+              "description": "The date this coffee was roasted, formatted as 'MM/DD/YYYY'."
+            }
+          },
+          "required": ["weight", "grind", "origin", "roaster", "roastDate"]
+        }
+      ],
+      "description": "The coffee beans used in your brew."
+    },
+    "water": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "weight": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+g$",
+                  "default": ""
+                }
+              ],
+              "description": "The weight of the water in grams, such as '500g'."
+            },
+            "temperature": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d+º[FC]$",
+                  "default": "212ºF"
+                }
+              ],
+              "description": "The temperature at which you began brewing."
+            },
+            "recipe": {
+              "type": "string",
+              "default": "",
+              "description": "The recipe you used for your water."
+            }
+          },
+          "required": ["weight", "temperature", "recipe"]
+        }
+      ],
+      "description": "The water used in your brew."
+    },
+    "equipment": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "default": "",
+          "description": "The method used to brew your coffee, such as 'Chemex' or 'Hario V60'."
+        },
+        "grinder": {
+          "type": "string",
+          "default": "",
+          "description": "The grinder make and model you used, such as 'Hario Skerton' or 'Baratza Encore'."
+        }
+      },
+      "description": "The equipment used to make this brew.",
+      "required": ["method", "grinder"]
+    },
+    "recipe": {
+      "type": "object",
+      "properties": {
+        "steep": {
+          "type": "object",
+          "properties": {
+            "time": {
+              "allOf": [
+                {
+                  "$schema": "https://json-schema.org/draft/2019-09/schema",
+                  "type": "string",
+                  "pattern": "^\\d{1}:\\d{2}$",
+                  "default": ""
+                }
+              ],
+              "description": "The total time from your initial pour on dry grounds to breaking the crust."
+            }
+          },
+          "description": "The steep settings you brewed with.",
+          "required": ["time"]
+        },
+        "notes": {
+          "type": "string",
+          "default": "",
+          "description": "Any notes on techniques used for your brew."
+        }
+      },
+      "description": "The techniques you used to brew.",
+      "required": ["steep", "notes"]
+    },
+    "time": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "string",
+          "pattern": "^\\d{1}:\\d{2}$",
+          "default": ""
+        }
+      ],
+      "description": "The total time from beginning of bloom until a steady stream suddenly falters to separate drops, such as '2:54'."
+    },
+    "aroma": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The smell (low to high), such as 'caramel', 'peach', or 'chocolate'."
+    },
+    "acidity": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The fruitiness (low to high), such as 'tart', 'crisp', or 'mellow'. Usually indicated by puckering/drying of the tongue or salivation."
+    },
+    "sweetness": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The sweetness (low to high), such as 'mild', 'deep', or 'rich'. Usually indicated by how 'rounded' the fruit quality is."
+    },
+    "body": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The texture or mouthfeel (light to heavy), such as 'watery', 'silky', 'syrupy', or 'creamy'."
+    },
+    "finish": {
+      "allOf": [
+        {
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+            "quantity": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how intense was it?"
+            },
+            "quality": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "default": 0,
+              "description": "On a scale of 1 to 5, how much did you enjoy it?"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "\\w+" },
+              "default": [],
+              "description": "Jot down your reactions to this aspect."
+            }
+          },
+          "required": ["quantity", "quality"]
+        }
+      ],
+      "description": "The aftertaste (short to long), such as 'quick', 'lingering', or 'clean'. Don't rush this aspect."
+    },
+    "notes": {
+      "type": "string",
+      "default": "",
+      "description": "Any notes about this brew, such as drawdown or overall flavor."
+    },
+    "score": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "default": 0,
+      "description": "On a scale of 1 to 10, how much did you enjoy this brew?"
+    },
+    "actionItem": {
+      "type": "string",
+      "default": "",
+      "description": "Any variables to change on the next brew."
+    }
+  },
+  "required": [
+    "type",
+    "date",
+    "coffee",
+    "water",
+    "equipment",
+    "recipe",
+    "time",
+    "aroma",
+    "acidity",
+    "sweetness",
+    "body",
+    "finish",
+    "notes",
+    "score",
+    "actionItem"
+  ]
+}

--- a/src/cli/journal/index.js
+++ b/src/cli/journal/index.js
@@ -39,6 +39,7 @@ import {
 
 const DEFAULT_FIELDS = {
   cupping: ['coffee.weight', 'coffee.grind', 'water', 'equipment', 'recipe'],
+  hybrid: ['coffee', 'water', 'equipment', 'recipe'],
   pourover: ['coffee', 'water', 'equipment', 'recipe']
 }
 
@@ -65,7 +66,7 @@ export const builder = yargs => yargs
   .positional('type', {
     describe: 'Type of journal entry',
     type: 'string',
-    choices: ['pourover', 'cupping'],
+    choices: ['cupping', 'hybrid', 'pourover'],
     required: true
   })
 export const handler = async ({ type, version = '1.1' }) => {

--- a/src/cli/journal/index.js
+++ b/src/cli/journal/index.js
@@ -29,6 +29,8 @@ import {
 } from '../../util';
 
 /**
+ * @todo Available journal entry types should be dynamically figured out from schemas folder, e.g. getSchemas().
+ * Use same function for update and stats commands.
  * @todo Should iteration start from 1?
  * then rework logic for generating filename from entry (perhaps a function like writeEntry(date, iteration, entry))
  * @todo Rework the handler to be more modular

--- a/src/cli/stats.js
+++ b/src/cli/stats.js
@@ -79,7 +79,7 @@ export const builder = yargs => yargs
   .positional('type', {
     describe: 'Type of journal entry',
     type: 'string',
-    choices: ['pourover', 'cupping'],
+    choices: ['cupping', 'hybrid', 'pourover'],
     required: true
   })
   .option('merge', {

--- a/src/cli/update.js
+++ b/src/cli/update.js
@@ -22,7 +22,7 @@ export const builder = yargs => yargs
   .positional('type', {
     describe: 'Type of journal entry',
     type: 'string',
-    choices: ['pourover', 'cupping'],
+    choices: ['cupping', 'hybrid', 'pourover'],
     required: true
   })
   .option('from', {

--- a/src/schema/hybrid.json
+++ b/src/schema/hybrid.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "../schemas/hybrid_v1.1.json",
+      "default": "../schemas/hybrid_v1.1.json",
+      "description": "The JSON schema to validate this journal entry against."
+    },
+    "type": {
+      "const": "hybrid",
+      "default": "hybrid",
+      "description": "The type of journal entry."
+    },
+    "date": {
+      "allOf": [{ "$ref": "./date.json" }],
+      "description": "The date you brewed this coffee, formatted as 'MM/DD/YYYY'."
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 0,
+      "description": "The (n - 1) coffee today."
+    },
+    "coffee": {
+      "allOf": [{ "$ref": "./coffee.json" }],
+      "description": "The coffee beans used in your brew."
+    },
+    "water": {
+      "allOf": [{ "$ref": "./water.json" }],
+      "description": "The water used in your brew."
+    },
+    "equipment": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "default": "",
+          "description": "The method used to brew your coffee, such as 'Chemex' or 'Hario V60'."
+        },
+        "grinder": {
+          "type": "string",
+          "default": "",
+          "description": "The grinder make and model you used, such as 'Hario Skerton' or 'Baratza Encore'."
+        }
+      },
+      "description": "The equipment used to make this brew.",
+      "required": ["method", "grinder"]
+    },
+    "recipe": {
+      "type": "object",
+      "properties": {
+        "steep": {
+          "type": "object",
+          "properties": {
+            "time": {
+              "allOf": [{ "$ref": "./time.json" }],
+              "description": "The total time from your initial pour on dry grounds to breaking the crust."
+            }
+          },
+          "description": "The steep settings you brewed with.",
+          "required": ["time"]
+        },
+        "notes": {
+          "type": "string",
+          "default": "",
+          "description": "Any notes on techniques used for your brew."
+        }
+      },
+      "description": "The techniques you used to brew.",
+      "required": ["steep", "notes"]
+    },
+    "time": {
+      "allOf": [{ "$ref": "./time.json" }],
+      "description": "The total time from beginning of bloom until a steady stream suddenly falters to separate drops, such as '2:54'."
+    },
+    "aroma": {
+      "allOf": [{ "$ref": "./aspect.json" }],
+      "description": "The smell (low to high), such as 'caramel', 'peach', or 'chocolate'."
+    },
+    "acidity": {
+      "allOf": [{ "$ref": "./aspect.json" }],
+      "description": "The fruitiness (low to high), such as 'tart', 'crisp', or 'mellow'. Usually indicated by puckering/drying of the tongue or salivation."
+    },
+    "sweetness": {
+      "allOf": [{ "$ref": "./aspect.json" }],
+      "description": "The sweetness (low to high), such as 'mild', 'deep', or 'rich'. Usually indicated by how 'rounded' the fruit quality is."
+    },
+    "body": {
+      "allOf": [{ "$ref": "./aspect.json" }],
+      "description": "The texture or mouthfeel (light to heavy), such as 'watery', 'silky', 'syrupy', or 'creamy'."
+    },
+    "finish": {
+      "allOf": [{ "$ref": "./aspect.json" }],
+      "description": "The aftertaste (short to long), such as 'quick', 'lingering', or 'clean'. Don't rush this aspect."
+    },
+    "notes": {
+      "type": "string",
+      "default": "",
+      "description": "Any notes about this brew, such as drawdown or overall flavor."
+    },
+    "score": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "default": 0,
+      "description": "On a scale of 1 to 10, how much did you enjoy this brew?"
+    },
+    "actionItem": {
+      "type": "string",
+      "default": "",
+      "description": "Any variables to change on the next brew."
+    }
+  },
+  "required": [
+    "type",
+    "date",
+    "coffee",
+    "water",
+    "equipment",
+    "recipe",
+    "time",
+    "aroma",
+    "acidity",
+    "sweetness",
+    "body",
+    "finish",
+    "notes",
+    "score",
+    "actionItem"
+  ]
+}


### PR DESCRIPTION
Adds new hybrid schema for coffee methods that use both immersion and percolation, such as Clever Dripper, Aeropress, and Delter Press.

```shell
kafi journal hybrid
kafi stats hybrid
```
