### PR TITLE
Add filepath option to stats for quick navigation to entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,24 +70,24 @@ kafi journal <cupping|hybrid|pourover>
 
 ```shell
 $ kafi stats pourover --coffee.origin.region="Pitalito"
-┌─────────┬──────────────┬─────────────────────────┬──────────────────────┬──────────────┬───────┐
-│ (index) │     date     │     coffee.roaster      │ coffee.origin.region │ coffee.grind │ score │
-├─────────┼──────────────┼─────────────────────────┼──────────────────────┼──────────────┼───────┤
-│    0    │ '09/25/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      23      │   7   │
-│    1    │ '09/26/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      23      │   2   │
-│    2    │ '09/27/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   3   │
-│    3    │ '09/28/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   8   │
-│    4    │ '09/29/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   9   │
-│    5    │ '09/30/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   5   │
-│    6    │ '10/01/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   8   │
-│    7    │ '10/02/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   7   │
-│    8    │ '10/03/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   8   │
-│    9    │ '10/04/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   5   │
-│   10    │ '10/05/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      25      │   7   │
-│   11    │ '10/06/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   7   │
-│   12    │ '10/07/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   7   │
-│   13    │ '10/08/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │   8   │
-└─────────┴──────────────┴─────────────────────────┴──────────────────────┴──────────────┴───────┘
+┌─────────┬──────────────┬─────────────────────────┬──────────────────────┬──────────────┬───────────────────┬────────┬───────┬───────────────────────────┐
+│ (index) │     date     │     coffee.roaster      │ coffee.origin.region │ coffee.grind │ water.temperature │  time  │ score │         filepath          │
+├─────────┼──────────────┼─────────────────────────┼──────────────────────┼──────────────┼───────────────────┼────────┼───────┼───────────────────────────┤
+│    0    │ '09/25/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      23      │      '212ºF'      │ '2:41' │   7   │ 'entries/09-25-2020.json' │
+│    1    │ '09/26/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      23      │      '212ºF'      │ '2:50' │   2   │ 'entries/09-26-2020.json' │
+│    2    │ '09/27/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '3:06' │   3   │ 'entries/09-27-2020.json' │
+│    3    │ '09/28/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:40' │   8   │ 'entries/09-28-2020.json' │
+│    4    │ '09/29/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:40' │   9   │ 'entries/09-29-2020.json' │
+│    5    │ '09/30/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:35' │   5   │ 'entries/09-30-2020.json' │
+│    6    │ '10/01/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:46' │   8   │ 'entries/10-01-2020.json' │
+│    7    │ '10/02/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:48' │   7   │ 'entries/10-02-2020.json' │
+│    8    │ '10/03/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:44' │   8   │ 'entries/10-03-2020.json' │
+│    9    │ '10/04/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:51' │   5   │ 'entries/10-04-2020.json' │
+│   10    │ '10/05/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      25      │      '212ºF'      │ '2:52' │   7   │ 'entries/10-05-2020.json' │
+│   11    │ '10/06/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:47' │   7   │ 'entries/10-06-2020.json' │
+│   12    │ '10/07/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '2:31' │   7   │ 'entries/10-07-2020.json' │
+│   13    │ '10/08/2020' │ 'Madcap Coffee Company' │      'Pitalito'      │      24      │      '212ºF'      │ '3:03' │   8   │ 'entries/10-08-2020.json' │
+└─────────┴──────────────┴─────────────────────────┴──────────────────────┴──────────────┴───────────────────┴────────┴───────┴───────────────────────────┘
 ```
 
 ```shell
@@ -95,7 +95,7 @@ $ kafi stats pourover --coffee.origin.region="Pitalito"
 kafi stats <cupping|hybrid|pourover>
 # Limit entries (defaults to last 30)
 kafi stats pourover --limit 10
-# Display specific fields (defaults to coffee.roaster, coffee.origin.country, coffee.grind, score)
+# Display specific fields (defaults to coffee.roaster, coffee.origin.country, coffee.grind, score, filepath)
 kafi stats pourover --fields coffee.origin.region coffee.grind time
 # Sort by fields (defaults to date)
 kafi stats pourover --sort coffee.roaster score coffee.grind

--- a/src/cli/journal/index.js
+++ b/src/cli/journal/index.js
@@ -31,6 +31,7 @@ import {
 } from '../../util';
 
 /**
+ * @todo Add --clone {filepath} flag to specify a different entry to clone
  * @todo Available journal entry types should be dynamically figured out from schemas folder, e.g. getSchemas().
  * Use same function for update and stats commands.
  * @todo Should iteration start from 1?

--- a/src/cli/stats.js
+++ b/src/cli/stats.js
@@ -4,6 +4,7 @@ import {
   dateFromFriendlyDate,
   getEntryByFilename,
   getEntryFilenames,
+  getRelativeFilepathByEntryName,
   mapAsync,
   partialEq,
   pathString
@@ -52,7 +53,7 @@ const {
  */
 
 const DEFAULT_SORT_FIELDS = ['date'];
-const DEFAULT_FIELDS = ['coffee.roaster', 'coffee.origin.region', 'coffee.grind', 'water.temperature', 'time', 'score'];
+const DEFAULT_FIELDS = ['coffee.roaster', 'coffee.origin.region', 'coffee.grind', 'water.temperature', 'time', 'score', 'filepath'];
 
 const isNumber = both(
   num => typeof num === 'number',
@@ -106,7 +107,9 @@ export const handler = ({ ['$0']: pos, _, stats, fn, fields, limit, merge, sort:
   const sort = merge ? [merge] : _sort;
   return pipeWith(andThen, [
     getEntryFilenames,
-    mapAsync(getEntryByFilename),
+    mapAsync(async filename => {
+      return { ...(await getEntryByFilename(filename)), filepath: await getRelativeFilepathByEntryName(filename) }
+    }),
     filter(partialEq(filters)),
     sortWith([
       ...map(


### PR DESCRIPTION
`kafi stats {pourover|cupping|hybrid} --fields filepath` (default field)